### PR TITLE
Add proper vat_label for Morocco

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -988,6 +988,7 @@
             <field file="base/static/img/country_flags/ma.png" name="image" type="base64" />
             <field name="currency_id" ref="MAD" />
             <field eval="212" name="phone_code" />
+            <field name="vat_label">ICE</field>
         </record>
         <record id="mc" model="res.country">
             <field name="name">Monaco</field>


### PR DESCRIPTION
As per the new morccan regulations, each company can now be identified by an unique Taxe N° which is called "ICE" (https://www.ice.gov.ma/ICE/Note.pdf). I think it's better to work with base Odoo fields than adding a new "ice" field like suggested in this PR: https://github.com/odoo/odoo/pull/32297

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
